### PR TITLE
Clean-up npm scripts (and make them work on Windows)

### DIFF
--- a/example/test/integration.js
+++ b/example/test/integration.js
@@ -4,10 +4,11 @@ var qs      = require('querystring');
 var host    = "http://127.0.0.1:";
 var port    = Math.floor(Math.random() * 9000) + 1000;
 
+process.env.PORT = port;
 // var server = require('../server');
 
 var exec = require('child_process').exec;
-exec('PORT='+port +' node ./example/server.js', function(error, stdout, stderr) {
+exec('node ./example/server.js', function(error, stdout, stderr) {
   // console.log(stdout);             // uncomment for console.log
   // console.log('stderr: ', stderr); // uncomment for errors
   if (error !== null) {

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "A JSON Web Tokens Tutorial to secure your node.js apps!",
   "main": "server.js",
   "scripts": {
-    "functional": "./node_modules/.bin/istanbul cover ./node_modules/tape/bin/tape ./example/test/functional.js | node_modules/tap-spec/bin/cmd.js",
-    "coverage": "./node_modules/.bin/istanbul cover ./node_modules/tape/bin/tape ./example/test/functional.js && ./node_modules/.bin/istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
-    "test": "./node_modules/tape/bin/tape ./example/test/integration.js | node_modules/tap-spec/bin/cmd.js",
+    "functional": "istanbul cover ./node_modules/tape/bin/tape ./example/test/functional.js | tap-spec",
+    "coverage": "istanbul cover ./node_modules/tape/bin/tape ./example/test/functional.js && istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
+    "test": "tape ./example/test/integration.js | tap-spec",
     "start": "node ./example/server.js",
-    "jshint": "./node_modules/jshint/bin/jshint -c .jshintrc --exclude-path .gitignore .",
+    "jshint": "jshint -c .jshintrc --exclude-path .gitignore .",
     "codeclimate": "CODECLIMATE_REPO_TOKEN=3f3e469b51750023cd2f400e639e3f9197917ba68efe8c63a19ae983895c8149 codeclimate ./node_modules/codeclimate-test-reporter/bin/codeclimate.js < ./coverage/lcov.info"
   },
   "repository": {


### PR DESCRIPTION
I'm on Windows, and when working with #29, had to fix the npm scripts in order to get my changes tested. Here are the changes in case you'd like to pull these in.

Note: please test the commands in your (non-Windows) OS to double-check they still work as expected.

Some references about the fixes:

- https://github.com/npm/npm/issues/4040#issuecomment-27159695 (about not having /.bin/ dir in the scripts)
- https://github.com/npm/npm/issues/2800#issuecomment-15379469 (about how to set env vars for test env in cross-platform way)
